### PR TITLE
Fix issue with cache key not containing arguments

### DIFF
--- a/src/lib/api/dataproduct.ts
+++ b/src/lib/api/dataproduct.ts
@@ -13,7 +13,7 @@ const dataProductCache = {}
 
 export async function getDataProduct(definition: string, source: string, args: object) {
   // Check if already available in cache
-  const cacheKey = `${definition}?source=${source}`
+  const cacheKey = `${definition}?source=${source}&args=` + JSON.stringify(args)
   const ts = Date.now()
   if (dataProductCache[cacheKey] && dataProductCache[cacheKey].expires > ts) {
     await sleep(config.fakeRequestTime) // We want it to look like there's always a request


### PR DESCRIPTION
The cache key didn't contain arguments, so if different parameters (like different product) was requested from the same source, data for another product could be returned from the cache by accident.

This simple fix encodes the arguents into the cache key to solve the issue.